### PR TITLE
Dataref array

### DIFF
--- a/CallbackManager/include/Dataref.h
+++ b/CallbackManager/include/Dataref.h
@@ -92,6 +92,9 @@ protected:
 	XPLMDataRef m_dataref;	/* Represent a void pointer locating the dataref as X - Plane SDK */
 	Dataref::Type m_type;	/* Represent the underlying data type of the dataref */
 	Logger m_logger;		/* The logger */
+
+	int setFloatArrayFromJson(int offset, std::string value);
+	int setIntArrayFromJson(int offset, std::string value);
 };
 
 

--- a/CallbackManager/include/Dataref.h
+++ b/CallbackManager/include/Dataref.h
@@ -2,8 +2,13 @@
 #include <string>
 #include <map>
 #include "Logger.h"
+
+#include <nlohmann/json.hpp>
+
 #include <XPLMDataAccess.h>
 
+
+using json = nlohmann::json;
 
 ///<summary>
 /// This class represent an X-Plane dataref in OOP format.

--- a/CallbackManager/src/CallbackManager.cpp
+++ b/CallbackManager/src/CallbackManager.cpp
@@ -143,8 +143,8 @@ int CallbackManager::ExecuteCallback(json* jsonData)
 		return 0x02;
 	}
 
-	XPLMDebugString(("Operation '" + operation + "' founded in callback").c_str());
-	m_logger.Log("Operation '" + operation + "' founded in callback\n");
+	XPLMDebugString(("Operation '" + operation + "' founded in callback\n").c_str());
+	m_logger.Log("Operation '" + operation + "' founded in callback");
 
 	int res = m_callbacks->at(operation)(jsonData, this);
 	

--- a/CallbackManager/src/CallbackManager.cpp
+++ b/CallbackManager/src/CallbackManager.cpp
@@ -134,21 +134,21 @@ int CallbackManager::ExecuteCallback(json* jsonData)
 	
 	std::string operation = jsonData->at("Operation").get<std::string>();
 	m_logger.Log("Operation '" + operation + "' was requested");
-	XPLMDebugString(("Operation '" + operation + "' was requested").c_str());
+	XPLMDebugString(("Operation '" + operation + "' was requested\n").c_str());
 
 	if (!m_callbacks->contains(operation))
 	{
 		m_logger.Log("Operation '" + operation + "' was not found", Logger::Severity::WARNING);
-		XPLMDebugString(("Operation '" + operation + "' was not found").c_str());
+		XPLMDebugString(("Operation '" + operation + "' was not found\n").c_str());
 		return 0x02;
 	}
 
 	XPLMDebugString(("Operation '" + operation + "' founded in callback").c_str());
-	m_logger.Log("Operation '" + operation + "' founded in callback");
+	m_logger.Log("Operation '" + operation + "' founded in callback\n");
 
 	int res = m_callbacks->at(operation)(jsonData, this);
 	
-	XPLMDebugString(("Operation '" + operation + "' executed and returned code : '" + std::to_string(res) + "'").c_str());
+	XPLMDebugString(("Operation '" + operation + "' executed and returned code : '" + std::to_string(res) + "'\n").c_str());
 	m_logger.Log("Operation '" + operation + "' executed and returned code : '" + std::to_string(res) + "'");
 	
 	return res;

--- a/CallbackManager/src/Dataref.cpp
+++ b/CallbackManager/src/Dataref.cpp
@@ -163,9 +163,18 @@ void Dataref::SetValue(std::string value)
 		break;
 	}
 	case Dataref::Type::FloatArray:
+	{
+		m_logger.Log("Calling 'setFloatArrayFromJson'", Logger::Severity::TRACE);
+		int res = this->setFloatArrayFromJson(0, value);
+		m_logger.Log("SetFloatArrayFromJson returned " + std::to_string(res) + "\n");
 		break;
+	}
 	case Dataref::Type::IntArray:
+	{
+		int res = this->setIntArrayFromJson(0, value);
+		m_logger.Log("SetIntArrayFromJson returned " + std::to_string(res) + "\n");
 		break;
+	}
 	case Dataref::Type::Data:
 		break;
 	default:
@@ -173,4 +182,109 @@ void Dataref::SetValue(std::string value)
 	}
 }
 
+int Dataref::setFloatArrayFromJson(int offset, std::string value)
+{
+	
+	std::vector<float> data;
+	int maxSize = XPLMGetDatavf(m_dataref, nullptr, 0, 0);
+	m_logger.Log("Max Size is '" + std::to_string(maxSize) + " '", Logger::Severity::TRACE);
+	int f_offset(offset);
+	json j = json::parse(value, nullptr, false, false);
+	if (j.type() == json::value_t::discarded)
+	{
+		m_logger.Log("FloatArray : json parsing of value failed!", Logger::Severity::CRITICAL);
+		XPLMDebugString("FloatArray6b\n");
+		return -1;
+	}
+	else if (j.type() == json::value_t::array)
+	{
+		m_logger.Log("FloatArray : value is an array!", Logger::Severity::DEBUG);
+		if ((int)j.size() < maxSize)
+			maxSize = (int)j.size();
+		m_logger.Log("FloatArray : max size is " + std::to_string(maxSize), Logger::Severity::CRITICAL);
+		data = j.get<std::vector<float>>();
+	}
+	else if (j.type() == json::value_t::number_float)
+	{
+		m_logger.Log("FloatArray : value is an float!", Logger::Severity::DEBUG);
+		for (int i(0); i < maxSize; i++)
+		{
+			data.push_back(j.get<float>());
+		}
+	}
+	else if (j.type() == json::value_t::string)
+	{
+		m_logger.Log("FloatArray : value is an string!", Logger::Severity::DEBUG);
+		for (int i(0); i < maxSize; i++)
+		{
+			data.push_back(std::stof(j.get<std::string>()));
+		}
+		XPLMDebugString("FloatArray9c\n");
+	}
+	else if (j.type() == json::value_t::object)
+	{
+		if (!j.contains("Value"))
+		{
+			m_logger.Log("FloatArray : json is not an array and doesn't contain a Value field", Logger::Severity::CRITICAL);
+			return -2;
+		}
+		if (j.contains("Offset"))
+		{
+			if (j["Offset"].type() == json::value_t::string)
+			{
+				f_offset = std::stoi(j["Offset"].get<std:: string>());
+			}
+			else
+			{
+				m_logger.Log("FloatArray : Offset field exist but is not string... skipping", Logger::Severity::WARNING);
+				f_offset = 0;
+			}
+		}
+		return setFloatArrayFromJson(f_offset, j["Value"].dump());
+	}
+	m_logger.Log("FloatArray: Size : " + std::to_string(maxSize) + "Offset : " + std::to_string(offset), Logger::Severity::TRACE);
+	data.resize(maxSize);
+	XPLMSetDatavf(m_dataref, data.data(), offset, maxSize);
+	return EXIT_SUCCESS;
+}
 
+int Dataref::setIntArrayFromJson(int offset, std::string value)
+{
+	std::vector<int> data;
+	int maxSize = XPLMGetDatavi(m_dataref, nullptr, 0, 0);
+	int f_offset(offset);
+	json j = json::parse(value, nullptr, false, false);
+	if (j.type() == json::value_t::discarded)
+	{
+		m_logger.Log("IntArray : json parsing of value failed!",  Logger::Severity::CRITICAL);
+		return -1;
+	}
+	else if (j.type() == json::value_t::array)
+	{
+		if ((int)j.size() < maxSize)
+			maxSize = (int)j.size();
+		data = j.get<std::vector<int>>();
+	}
+	else if (j.type() == json::value_t::number_integer || j.type() == json::value_t::number_unsigned)
+	{
+		for (int i(0); i < maxSize; i++)
+		{
+			data.push_back(j.get<int>());
+		}
+	}
+	else if (j.type() == json::value_t::object)
+	{
+		if (!j.contains("Value"))
+		{
+			std::cout << "IntArray : json is not an array and doesn't contain a Value field\tCRITICAL\n";
+			return -2;
+		}
+		if (j.contains("Offset"))
+			f_offset = j["Offset"].get<int>();
+
+		return setFloatArrayFromJson(f_offset, j["Value"].dump());
+	}
+	data.resize(maxSize);
+	XPLMSetDatavi(m_dataref, data.data(), offset, maxSize);
+	return EXIT_SUCCESS;
+}

--- a/CallbackManager/src/Dataref.cpp
+++ b/CallbackManager/src/Dataref.cpp
@@ -99,9 +99,33 @@ std::string Dataref::GetValue()
 		value = std::to_string(XPLMGetDatad(m_dataref));
 		break;
 	case Dataref::Type::FloatArray:
+	{
+		int arraySize = XPLMGetDatavf(m_dataref, nullptr, 0, 0);
+		XPLMSpeakString(("Array is " + std::to_string(arraySize) + " lenght").c_str());
+		float* floatArray = (float*)malloc(sizeof(float) * arraySize);
+		XPLMGetDatavf(m_dataref, floatArray, 0, arraySize);
+		json j = json::array();
+		for (int i = 0; i < arraySize; i++)
+		{
+			j.push_back(*(floatArray + i));
+		}
+		value = j.dump();
 		break;
+	}
 	case Dataref::Type::IntArray:
+	{
+		int arraySize = XPLMGetDatavi(m_dataref, nullptr, 0, 0);
+		XPLMSpeakString(("Array is " + std::to_string(arraySize) + " lenght").c_str());
+		int* intArray = (int*)malloc(sizeof(int) * arraySize);
+		XPLMGetDatavi(m_dataref, intArray, 0, arraySize);
+		json j = json::array();
+		for (int i = 0; i < arraySize; i++)
+		{
+			j.push_back(*(intArray + i));
+		}
+		value = j.dump();
 		break;
+	}
 	case Dataref::Type::Data:
 		break;
 	default:

--- a/DefaultCallbacks/src/Callbacks.cpp
+++ b/DefaultCallbacks/src/Callbacks.cpp
@@ -248,6 +248,6 @@ int Speak(json* jdata, CallbackManager* callback)
 {
 	if(!jdata->contains("Text"))
 		return 0x01;
-	XPLMDebugString(jdata->at("Text").get<std::string>().c_str());
+	XPLMSpeakString(jdata->at("Text").get<std::string>().c_str());
 	return 0;
 }

--- a/DefaultCallbacks/src/Callbacks.cpp
+++ b/DefaultCallbacks/src/Callbacks.cpp
@@ -264,11 +264,6 @@ int SetDatarefValue(json* jdata, CallbackManager* callback)
 		callback->Log("Value and/or Link propertie(s) missing from JSON", Logger::Severity::CRITICAL);
 		return 0x01;
 	}
-	if (jdata->at("Value").type() != json::value_t::string)
-	{
-		callback->Log("Value property must be a string", Logger::Severity::CRITICAL);
-		return 0x02;
-	}
 	std::string value = ExtractJsonValue(jdata, "Value", callback);
 	if (value.length() <= 0)
 	{

--- a/DefaultCallbacks/src/Callbacks.h
+++ b/DefaultCallbacks/src/Callbacks.h
@@ -13,6 +13,8 @@ using json = nlohmann::json;
 
 constexpr int CallbackNumber = 10;
 
+std::string ExtractJsonValue(json* jdata, std::string fieldname, CallbackManager* callback);
+
 ///<summary>
 /// Manadatory function to implement.
 /// Caution when callbacks is NULL, the function should only return the number of callback

--- a/XPLMServer/src/main.cpp
+++ b/XPLMServer/src/main.cpp
@@ -32,7 +32,7 @@ PLUGIN_API int XPluginStart(char* outName, char* outSig, char* outDesc)
 	auto data = loadFile(".\\Resources\\plugins\\XPLMServer\\pluginConfig.json");
 	if (data.str().length() < 1)
 	{
-		XPLMDebugString("[XPLMServer]Unable to load configuration file");
+		XPLMDebugString("[XPLMServer]Unable to load configuration file\n");
 		return 0;
 	}
 
@@ -68,7 +68,7 @@ PLUGIN_API void XPluginDisable(void)
 
 PLUGIN_API int  XPluginEnable(void)
 { 
-	XPLMDebugString("[XPLMServer]Enabled");
+	XPLMDebugString("[XPLMServer]Enabled\n");
 	std::string configuration;
 	#ifndef _DEBUG
 		configuration = "Release";
@@ -82,9 +82,7 @@ PLUGIN_API int  XPluginEnable(void)
 	platform = "Win64";
 	#endif
 	std::string dllPath = PluginConfiguration["DLLFiles"][platform][configuration].get<std::string>();
-	
-	std::string dllLog = "[XPLMServer]Trying to load dll from path : '" + dllPath + "'\n";
-	XPLMDebugString(dllLog.c_str());
+	XPLMDebugString(("[XPLMServer]Trying to load dll from path : '" + dllPath + "'\n").c_str());
 	XPLMDebugString("[XPLMServer]Creating a callback manager...\n");
 	callbackManager = new CallbackManager();
 	XPLMDebugString("[XPLMServer]Creating a callback manager...[DONE]\n");


### PR DESCRIPTION
Implementing #2

Float and Int array are correctly maniplated. Int and Float array can be manipluated either via array

`"Value" = '1.0'` will fill up the whole array with 1.0 
`"Value" = ['1.0']` will fill up the first slot to 1.0
`"Value" = ['1.0', '1.2', ...]` will fill up the dataref array with value up to the array dataref array size or json array size witch ever is less
`"Value" = "{"Offset" : '2', "Value" : "**val**"}"` will fill up the array starting at offset, value can be one of the above.

In addition this also implement new callback function (not exported) to extract json value correctly. 